### PR TITLE
Grid fit classes

### DIFF
--- a/_include-media-grid.scss
+++ b/_include-media-grid.scss
@@ -115,18 +115,21 @@ $im-grid-include-max-width: false !default;
 }
 
 /*
+    Grid fit
+*/
+.#{$im-grid-class}--fit > .#{$im-grid-cell-class} {
+    flex: 1;
+}
+.#{$im-grid-class}--full > .#{$im-grid-cell-class} {
+    flex: 0 0 100%;
+}
+
+/*
     Generate grid classes
 */
 @mixin im-grid-columns($columns...) {
     @each $i in $columns {
         @for $n from 1 through $i {
-            .#{$im-grid-class}--fit > .#{$im-grid-cell-class} {
-                flex: 1;
-            }
-            .#{$im-grid-class}--full > .#{$im-grid-cell-class} {
-                flex: 0 0 100%;
-            }
-
             .#{$im-grid-class}--#{$n}-#{$i} > .#{$im-grid-cell-class}:not([class*='#{$im-grid-cell-class}--']) {
                 flex: 0 0 (($n / $i) * 100%);
                 @if $im-grid-include-max-width


### PR DESCRIPTION
These classes render multiple times (one for each column passed in the parameters):
.grid--fit > .grid-cell { ... }
.grid--full > .grid-cell{ ... }

I thought it's unnecessary, so I took them out of the columns loop, and it works well.
Let me know your thoughts. 
Cheers!